### PR TITLE
✨️ Markdownのヘッダーと段落をHTMLに変換

### DIFF
--- a/cmd/mdparser/main.go
+++ b/cmd/mdparser/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	input := "# Hello\n\nThis is *Markdown*."
+	input := "# h1\n\n## h2\n\n### h3\n\n#### h4\n\n##### h5\n\n###### h6\n\nThis is *Markdown*."
 	html := parser.Parse(input)
 	fmt.Println(html)
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,5 +1,26 @@
 package parser
 
+import (
+	"strings"
+)
+
 func Parse(input string) string {
-	return input
+	lines := strings.Split(input, "\n")
+	var out []string
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if content, ok := strings.CutPrefix(line, "# "); ok {
+			out = append(out, "<h1>"+content+"</h1>")
+			continue
+		}
+
+		out = append(out, "<p>"+line+"</p>")
+	}
+
+	return strings.Join(out, "\n")
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -8,14 +8,14 @@ func Parse(input string) string {
 	lines := strings.Split(input, "\n")
 	var out []string
 
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
 		if line == "" {
 			continue
 		}
 
-		if content, ok := strings.CutPrefix(line, "# "); ok {
-			out = append(out, "<h1>"+content+"</h1>")
+		if content, ok := parseHeading(line); ok {
+			out = append(out, content)
 			continue
 		}
 
@@ -23,4 +23,23 @@ func Parse(input string) string {
 	}
 
 	return strings.Join(out, "\n")
+}
+
+func parseHeading(line string) (string, bool) {
+	switch {
+	case strings.HasPrefix(line, "###### "):
+		return "<h6>" + strings.TrimPrefix(line, "###### ") + "</h6>", true
+	case strings.HasPrefix(line, "##### "):
+		return "<h5>" + strings.TrimPrefix(line, "##### ") + "</h5>", true
+	case strings.HasPrefix(line, "#### "):
+		return "<h4>" + strings.TrimPrefix(line, "#### ") + "</h4>", true
+	case strings.HasPrefix(line, "### "):
+		return "<h3>" + strings.TrimPrefix(line, "### ") + "</h3>", true
+	case strings.HasPrefix(line, "## "):
+		return "<h2>" + strings.TrimPrefix(line, "## ") + "</h2>", true
+	case strings.HasPrefix(line, "# "):
+		return "<h1>" + strings.TrimPrefix(line, "# ") + "</h1>", true
+	default:
+		return "", false
+	}
 }


### PR DESCRIPTION
# 概要

パース処理を拡張し、Markdownのヘッダー（h1 ~ h6）と段落をHTMLに変換する

# 変更内容

- Markdownのヘッダー及び段落をHTMLに変換する処理を実装

# 動作確認

- [x] プロジェクトルートで `go run cmd/mdparser/main.go` を実行、以下の出力が得られる

```
<h1>h1</h1>
<h2>h2</h2>
<h3>h3</h3>
<h4>h4</h4>
<h5>h5</h5>
<h6>h6</h6>
<p>This is *Markdown*.</p>
```