### PR TITLE
✨️ インライン要素をHTMLに変換する処理を実装

### DIFF
--- a/cmd/mdparser/main.go
+++ b/cmd/mdparser/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	input := "# h1\n\n## h2\n\n### h3\n\n#### h4\n\n##### h5\n\n###### h6\n\nThis is *Markdown*."
+	input := "# h1\n\nThis is *Markdown* with **strong** and `code`."
 	html := parser.Parse(input)
 	fmt.Println(html)
 }

--- a/internal/parser/inline.go
+++ b/internal/parser/inline.go
@@ -77,3 +77,22 @@ func mergeTextTokens(tokens []InlineToken) []InlineToken {
 	merged = append(merged, current)
 	return merged
 }
+
+func RenderInline(tokens []InlineToken) string {
+	var b strings.Builder
+
+	for _, token := range tokens {
+		switch token.Type {
+		case TokenText:
+			b.WriteString(token.Text)
+		case TokenEmphasis:
+			b.WriteString("<em>" + token.Text + "</em>")
+		case TokenStrong:
+			b.WriteString("<strong>" + token.Text + "</strong>")
+		case TokenCode:
+			b.WriteString("<code>" + token.Text + "</code>")
+		}
+	}
+
+	return b.String()
+}

--- a/internal/parser/inline.go
+++ b/internal/parser/inline.go
@@ -54,3 +54,26 @@ func TokenizeInline(input string) []InlineToken {
 
 	return mergeTextTokens(tokens)
 }
+
+func mergeTextTokens(tokens []InlineToken) []InlineToken {
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	var merged []InlineToken
+	current := tokens[0]
+
+	for i := 1; i < len(tokens); i++ {
+		t := tokens[i]
+		if current.Type == TokenText && t.Type == TokenText {
+			current.Text += t.Text
+			continue
+		}
+
+		merged = append(merged, current)
+		current = t
+	}
+
+	merged = append(merged, current)
+	return merged
+}

--- a/internal/parser/inline.go
+++ b/internal/parser/inline.go
@@ -1,0 +1,56 @@
+package parser
+
+import "strings"
+
+type InlineTokenType int
+
+const (
+	TokenText InlineTokenType = iota
+	TokenEmphasis
+	TokenStrong
+	TokenCode
+)
+
+type InlineToken struct {
+	Type InlineTokenType
+	Text string
+	URL  string
+}
+
+func TokenizeInline(input string) []InlineToken {
+	var tokens []InlineToken
+
+	for len(input) > 0 {
+		switch {
+		case strings.HasPrefix(input, "**"):
+			end := strings.Index(input[2:], "**")
+			if end >= 0 {
+				text := input[2 : 2+end]
+				tokens = append(tokens, InlineToken{Type: TokenStrong, Text: text})
+				input = input[2+end+2:]
+				continue
+			}
+		case strings.HasPrefix(input, "*"):
+			end := strings.Index(input[1:], "*")
+			if end >= 0 {
+				text := input[1 : 1+end]
+				tokens = append(tokens, InlineToken{Type: TokenEmphasis, Text: text})
+				input = input[1+end+1:]
+				continue
+			}
+		case strings.HasPrefix(input, "`"):
+			end := strings.Index(input[1:], "`")
+			if end >= 0 {
+				text := input[1 : 1+end]
+				tokens = append(tokens, InlineToken{Type: TokenCode, Text: text})
+				input = input[1+end+1:]
+				continue
+			}
+		}
+
+		tokens = append(tokens, InlineToken{Type: TokenText, Text: string(input[0])})
+		input = input[1:]
+	}
+
+	return mergeTextTokens(tokens)
+}

--- a/internal/parser/inline.go
+++ b/internal/parser/inline.go
@@ -96,3 +96,7 @@ func RenderInline(tokens []InlineToken) string {
 
 	return b.String()
 }
+
+func renderParagraph(line string) string {
+	return "<p>" + RenderInline(TokenizeInline(line)) + "</p>"
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -19,7 +19,7 @@ func Parse(input string) string {
 			continue
 		}
 
-		out = append(out, "<p>"+line+"</p>")
+		out = append(out, renderParagraph(line))
 	}
 
 	return strings.Join(out, "\n")


### PR DESCRIPTION
# 概要

インライン要素をHTMLに変換する処理を実装した

# 変更内容

- インライン要素のトークン化する処理を実装 
- トークン化したインライン要素をHTMLに変換する処理を実装

# 動作確認

- [x] ルートディレクトリで `go run cmd/mdparser/main.go` を実行し、以下の出力が得られる

```
<h1>h1</h1>
<p>This is <em>Markdown</em> with <strong>strong</strong> and <code>code</code>.</p>
```